### PR TITLE
streamline API responses

### DIFF
--- a/frontend/app/api.py
+++ b/frontend/app/api.py
@@ -3,7 +3,9 @@ import json
 
 from zomstream import Zomstream
 
-api_version = "0.1"
+api_version = "0.2"
+api_base = "/api/v" + api_version
+
 api = flask.Blueprint('api', __name__)
 zomstream = Zomstream()
 
@@ -11,20 +13,19 @@ def construct_response(streams):
     # Expecting a JSON-serializable list as an argument
     # Returning a JSON string with the API response
 
-    # Add Version String
-    r = {"version":api_version,
-         "streams":streams}
+    r = {"streams":streams}
     return flask.jsonify(r)
 
-
-@api.route("/api/stream/", methods = ['GET'])
-@api.route("/api/streams/", methods = ['GET'])
+@api.route(api_base + "/streams/", methods = ['GET'])
 def api_list_streams():
-    return construct_response(zomstream.getStreams())
+    streams = []
+    for stream in zomstream.getStreamNames():
+        streams.append({'app':stream[0],'name':stream[1]})
+    return construct_response(streams)
 
 
-@api.route("/api/stream/<app_name>/<stream_name>/", methods = ['GET'])
-def api_stream(app_name, stream_name):
+@api.route(api_base + "/streams/<stream_name>/", methods = ['GET'])
+def api_stream( stream_name):
     # Filter for streams with 'name' == stream_name
     stream = list(filter(lambda stream: stream['name'] == stream_name, zomstream.getStreams()))
     return construct_response(stream)

--- a/frontend/app/zomstream.py
+++ b/frontend/app/zomstream.py
@@ -6,11 +6,10 @@ import urllib
 
 
 class Stream:
-    def __init__(self, url, name, streamType, app):
-        self.url = url
-        self.name = name
-        self.streamType = streamType
-        self.app = app
+    def __init__(self, app, name, urls):
+        self.name = name  # String
+        self.app = app    # String
+        self.urls = urls  # List of Dictionaries with the keys url and type
 
 
 class Zomstream:
@@ -24,6 +23,7 @@ class Zomstream:
             print('missing configuration.')
             sys.exit(1)
         self.streamnames = []
+
     def getStreamNames(self):
         self.streamnames = []
         # get data from the streaming server
@@ -49,11 +49,28 @@ class Zomstream:
     def getStreams(self):
         streams = []
         for streamName in self.getStreamNames():
-            stream_url = '%s://%s/flv?app=%s&stream=%s' % (
-                self.configuration['web_proto'],
-                self.configuration['base_url'],
-                streamName[0],
-                streamName[1])
-            stream = Stream(url=stream_url, app=streamName[0], name=streamName[1], streamType='http_flv')
+            urls = []
+            app  = streamName[0]
+            name = streamName[1]
+
+            flv_url  = self.getFlvUrl (app,name)
+            rtmp_url = self.getRtmpUrl(app,name)
+
+            urls.append({'url': flv_url, 'type':'http_flv'})
+            urls.append({'url': rtmp_url,'type':'rtmp'})
+
+            stream = Stream(app=app, name=name, urls=urls)
             streams.append(stream.__dict__)
         return streams
+
+    def getFlvUrl(self,app_name,stream_name):
+        return '%s://%s/flv?app=%s&stream=%s' % (
+            self.configuration['web_proto'],
+            self.configuration['base_url'],
+            app_name,
+            stream_name)
+    def getRtmpUrl(self,app_name,stream_name):
+        return "rtmp://%s/%s/%s" % (
+            self.configuration['rtmp_base'],
+            app_name,
+            stream_name)


### PR DESCRIPTION
The goal of this is to make the API more compliant with REST best practices.
This commit adds the API version to the request and removes it from the response.
The endpoint locations have been unified (i.e. always `/streams/` instead of
sometimes `/stream/` and sometimes `/streams/`.
Responses to requests that do not contain a stream name no longer contain urls.
The app has been removed from requests for stream information.
multiple urls can now be returned. I.e. that we now return both flv and rtmp link.